### PR TITLE
SSH adapter: if ssh password is given, use sshpass

### DIFF
--- a/lib/photocopier/ssh.rb
+++ b/lib/photocopier/ssh.rb
@@ -42,7 +42,6 @@ module Photocopier
       host = opts.delete(:host)
       user = opts.delete(:user)
       opts.delete(:gateway)
-      opts.delete(:sshpass)
       @session ||= if gateway_options.any?
                      gateway.ssh(host, user, opts)
                    else
@@ -93,18 +92,18 @@ module Photocopier
     def rsh_arguments
       arguments = []
       if gateway_options.any?
-        arguments << ssh_command(gateway_options, options[:sshpass])
+        arguments << ssh_command(gateway_options)
       end
-      arguments << ssh_command(options, gateway_options[:sshpass])
+      arguments << ssh_command(options)
       arguments.join(" ")
     end
 
-    def ssh_command(opts, use_sshpass=true)
+    def ssh_command(opts)
       command = "ssh "
       command << "-p #{opts[:port]} " if opts[:port].present?
       command << "#{opts[:user]}@" if opts[:user].present?
       command << opts[:host]
-      if opts[:password] && use_sshpass
+      if opts[:password]
         command = "sshpass -p #{opts[:password]} #{command}"
       end
       command
@@ -114,7 +113,6 @@ module Photocopier
       opts = gateway_options
       host = opts.delete(:host)
       user = opts.delete(:user)
-      opts.delete(:sshpass)
       @gateway ||= Net::SSH::Gateway.new(host, user, opts)
     end
 

--- a/lib/photocopier/version.rb
+++ b/lib/photocopier/version.rb
@@ -1,3 +1,3 @@
 module Photocopier
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end

--- a/spec/ssh_spec.rb
+++ b/spec/ssh_spec.rb
@@ -57,31 +57,23 @@ describe Photocopier::SSH do
     context "given a password" do
       let(:options) do { :host => "host", :password => "password" } end
 
-      context "sshpass is enabled" do
-        it "should be added to the command" do
-          ssh.send(:ssh_command, options, true).should == "sshpass -p password ssh host"
-        end
-      end
-
-      context "sshpass is disabled" do
-        it "should not change the command" do
-          ssh.send(:ssh_command, options, false).should == "ssh host"
-        end
+      it "sshpass should be added to the command" do
+        ssh.send(:ssh_command, options).should == "sshpass -p password ssh host"
       end
     end
   end
 
   context "#rsh_arguments" do
     it "should build arguments for rsync" do
-      ssh.should_receive(:ssh_command).with(options, anything)
+      ssh.should_receive(:ssh_command).with(options)
       ssh.send(:rsh_arguments)
     end
 
     context "given a gateway" do
       let(:options) { options_with_gateway }
       it "should include gateway options" do
-        ssh.should_receive(:ssh_command).with(gateway_config, anything)
-        ssh.should_receive(:ssh_command).with(options, anything)
+        ssh.should_receive(:ssh_command).with(gateway_config)
+        ssh.should_receive(:ssh_command).with(options)
         ssh.send(:rsh_arguments)
       end
     end


### PR DESCRIPTION
Assume that sshpass is the tool to be used if a password has been given, since the security has already been negated by a password written in the Movefile.

In addition, this should encourage people to stop putting passwords inside Movefiles (i.e. sshpass insn't installed)
