### PR TITLE
fix rsync_options escaping bug (escaped as single word)

### DIFF
--- a/lib/photocopier/ssh.rb
+++ b/lib/photocopier/ssh.rb
@@ -2,6 +2,7 @@ require 'net/ssh'
 require 'net/ssh/gateway'
 require 'net/scp'
 require 'fileutils'
+require 'shellwords'
 
 require 'photocopier/adapter'
 
@@ -75,7 +76,7 @@ module Photocopier
     end
 
     def rsync_command
-      [
+      command = [
         "rsync",
         "--progress",
         "-e",
@@ -84,8 +85,9 @@ module Photocopier
         "--compress",
         "--omit-dir-times",
         "--delete",
-        rsync_options
-      ].compact
+      ]
+      command.concat Shellwords.split(rsync_options) if rsync_options
+      command.compact
     end
 
     def rsync(source, destination, exclude = [])


### PR DESCRIPTION
Using more than one options in movefile>{env}>ssh>rsync_options doesn't work because the string is escaped as single shell word and rsync try to parse it as a single option

I used Shellwords.split (escape gem doesnt provide splitting) to do a shell-aware split so Escape.shell_command will later escape them as single options

maybe it would make sense to ditch the escape gem and just use the shellwords module from stdlib
(Shellwords.join can be used instead of Escape.shell_command)
