### PR TITLE
Adding quotes to local path

### DIFF
--- a/lib/photocopier/ftp.rb
+++ b/lib/photocopier/ftp.rb
@@ -52,7 +52,7 @@ module Photocopier
             "open #{remote_ftp_url}",
             "mkdir -p #{remote}",
             "cd #{remote}",
-            "lcd #{local}",
+            "lcd \"#{local}\"",
             lftp_mirror_arguments(reverse, exclude)
           ].join("; ")
     end


### PR DESCRIPTION
If your local path has spaces in it (ex: Windows), the lcd command will fail due to the path not being quoted.