### PR TITLE
Fix FTP permission error

### DIFF
--- a/lib/photocopier/ftp.rb
+++ b/lib/photocopier/ftp.rb
@@ -69,7 +69,7 @@ module Photocopier
     end
 
     def lftp_mirror_arguments(reverse, exclude = [])
-      mirror = "mirror --delete --use-cache --verbose --allow-chown --allow-suid --no-umask --parallel=5"
+      mirror = "mirror --delete --use-cache --verbose --no-perms --allow-suid --no-umask --parallel=5"
       mirror << " --reverse" if reverse
       exclude.each do |glob|
         mirror << " --exclude-glob #{glob}" # NOTE do not use Shellwords.escape here


### PR DESCRIPTION
Is chown necessary to a parameter?
It seems to cause several problems that I get up in wordmove.

- [SFTP issue · Issue #250 · welaika/wordmove](https://github.com/welaika/wordmove/issues/250)
- [LFTP doesn't sync folders · Issue #231 · welaika/wordmove](https://github.com/welaika/wordmove/issues/231)
- [mkdir: Access failed: 550 Can't create directory: No such file or directory · Issue #201 · welaika/wordmove](https://github.com/welaika/wordmove/issues/201)
