### PR TITLE
Support symlinks

### DIFF
--- a/lib/photocopier/ftp.rb
+++ b/lib/photocopier/ftp.rb
@@ -70,7 +70,7 @@ module Photocopier
 
     def lftp_mirror_arguments(reverse, exclude = [])
       mirror = "mirror --delete --use-cache --verbose --allow-chown --allow-suid --no-umask --parallel=5"
-      mirror << " --reverse" if reverse
+      mirror << " --reverse --dereference" if reverse
       exclude.each do |glob|
         mirror << " --exclude-glob #{glob}" # NOTE do not use Shellwords.escape here
       end

--- a/spec/ftp_spec.rb
+++ b/spec/ftp_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Photocopier::FTP do
         'find -d 1 remote\\ dir || mkdir -p remote\\ dir',
         'lcd local\\ dir',
         'cd remote\\ dir',
-        'mirror --delete --use-cache --verbose --allow-chown --allow-suid --no-umask --parallel=5 --reverse --exclude-glob .git --exclude-glob *.sql --exclude-glob bin/'
+        'mirror --delete --use-cache --verbose --allow-chown --allow-suid --no-umask --parallel=5 --reverse --dereference --exclude-glob .git --exclude-glob *.sql --exclude-glob bin/'
       ].join("; ")
       expect(ftp).to receive(:system).with("lftp -c '#{lftp_commands}'")
       ftp.send(:lftp, "local dir", "remote dir", true, [".git", "*.sql", "bin/"])

--- a/spec/ftp_spec.rb
+++ b/spec/ftp_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Photocopier::FTP do
     end
 
     it "should build args for reverse mirroring" do
-      lftp_arguments << "--reverse"
+      lftp_arguments << "--reverse --dereference"
       expect(ftp.send(:lftp_mirror_arguments, true, [])).to eq(lftp_arguments.join(" "))
     end
 


### PR DESCRIPTION
LSTP cannot create symbolic links when uploading to a remote server and will return an error if it finds any among the files to be transferred. By setting the dereference option LFTP will upload the files and folders that the symbolic links refer to instead.