### PR TITLE
accept ftp:ssl-allow option for lftp

### DIFF
--- a/lib/photocopier/ftp.rb
+++ b/lib/photocopier/ftp.rb
@@ -42,15 +42,19 @@ module Photocopier
     def lftp(local, remote, reverse, exclude)
       remote = Shellwords.escape(remote)
       local = Shellwords.escape(local)
-      command = [
+      cmds = [
           "set ftp:list-options -a",
-          "set cmd:fail-exit true",
+          "set cmd:fail-exit true"
+      ]
+      cmds = cmds + ["set ftp:ssl-allow #{options[:'ssl-allow']}"] if !options[:"ssl-allow"].nil?
+      cmds = cmds + [
           "open #{remote_ftp_url}",
           "find -d 1 #{remote} || mkdir -p #{remote}",
           "lcd #{local}",
           "cd #{remote}",
           lftp_mirror_arguments(reverse, exclude)
-      ].join("; ")
+      ]
+      command = cmds.join("; ")
 
       run "lftp -c '#{command}'"
     end


### PR DESCRIPTION
for networks that data connection of ftp is caught by the firewall when authenticated with ssl

cf. ssl-allow option in `man 1 lftp`

<blockquote>
<dl>
<dt>ftp:ssl-allow (boolean)</dt>
<dd>if true, try to negotiate SSL connection  with  FTP  server  for  non-anonymous  access.  Default is true. This and other SSL settings are only available if lftp was compiled  with  an  ssl/tls library.</dd>
</dl>
</blockquote>


